### PR TITLE
fix: isolate runAfter Ctrl-C during rebase

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,20 +1,23 @@
-name: Release Package
+name: Publish Test Package
 
 on:
   workflow_dispatch:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - master
+    inputs:
+      tag:
+        description: npm dist-tag for the test package
+        required: true
+        default: beta
+        type: choice
+        options:
+          - alpha
+          - beta
+          - next
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   build-foreground:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged
     strategy:
       fail-fast: false
       matrix:
@@ -72,8 +75,7 @@ jobs:
           path: bin/${{ matrix.package_target }}/foreground
           if-no-files-found: error
 
-  release-package:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged
+  publish-test:
     needs: build-foreground
     runs-on: ubuntu-latest
     steps:
@@ -82,6 +84,7 @@ jobs:
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - uses: pnpm/action-setup@v6.0.8
         with:
@@ -103,20 +106,25 @@ jobs:
           done
           find bin -maxdepth 2 -type f -print
 
-      - name: Version Package
-        id: versioning
-        run: |
-          pnpm changeset version
-          echo "tag=v$(node -pe "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-          git restore .
-
-      - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@v1.9.0
+      - name: Set timestamp prerelease version
+        id: test-version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        with:
-          version: pnpm changeset version
-          publish: pnpm changeset publish
-          commit: "chore: release ${{ steps.versioning.outputs.tag }}"
-          title: "chore: release ${{ steps.versioning.outputs.tag }}"
+          TEST_TAG: ${{ inputs.tag }}
+        run: |
+          timestamp="$(date -u +%Y%m%d%H%M%S)"
+          version="$(TIMESTAMP="$timestamp" node -e "const fs=require('fs'); const p=require('./package.json'); const base=p.version.split('-')[0]; p.version=base+'-'+process.env.TEST_TAG+'.'+process.env.TIMESTAMP; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n'); console.log(p.version)")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Prepared test version: $version"
+
+      - name: Build package
+        run: pnpm run build
+
+      - name: Publish test package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag "${{ inputs.tag }}"
+
+      - name: Summary
+        run: |
+          echo "Published lockfile-conflicts@${{ steps.test-version.outputs.version }} with tag ${{ inputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Install with: npm install lockfile-conflicts@${{ inputs.tag }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist
 types
 .idea
 .DS_Store
+
+# Native build output
+native/**/target
+bin

--- a/native/foreground/build.mjs
+++ b/native/foreground/build.mjs
@@ -1,0 +1,47 @@
+import { $, fs, path } from 'zx';
+
+const root = process.cwd();
+
+function readOption(name) {
+  const prefix = `${name}=`;
+  const index = process.argv.indexOf(name);
+  if (index !== -1) return process.argv[index + 1];
+  const item = process.argv.find((arg) => arg.startsWith(prefix));
+  return item ? item.slice(prefix.length) : undefined;
+}
+
+function linuxLibcSuffix() {
+  if (process.platform !== 'linux') return '';
+  const report = process.report?.getReport?.();
+  return report?.header?.glibcVersionRuntime ? '-gnu' : '-musl';
+}
+
+function defaultPackageTarget() {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+    throw new Error(`unsupported platform: ${process.platform}`);
+  }
+  if (process.arch !== 'x64' && process.arch !== 'arm64') {
+    throw new Error(`unsupported arch: ${process.arch}`);
+  }
+  return `${process.platform}-${process.arch}${linuxLibcSuffix()}`;
+}
+
+const packageTarget = readOption('--package-target') || defaultPackageTarget();
+const cc = readOption('--cc') || process.env.CC || 'cc';
+const extraCflags = (process.env.CFLAGS || '').split(/\s+/).filter(Boolean);
+function defaultLdflags() {
+  if (process.platform === 'darwin') return ['-Wl,-dead_strip'];
+  if (process.platform === 'linux') return ['-Wl,--gc-sections'];
+  return [];
+}
+
+const extraLdflags = (process.env.LDFLAGS || '').split(/\s+/).filter(Boolean);
+const ldflags = extraLdflags.length ? extraLdflags : defaultLdflags();
+const source = path.join(root, 'native/foreground/foreground.c');
+const destination = path.join(root, 'bin', packageTarget, 'foreground');
+
+await fs.ensureDir(path.dirname(destination));
+await $`${cc} -Os -s -fdata-sections -ffunction-sections ${extraCflags} ${source} ${ldflags} -o ${destination}`;
+await fs.chmod(destination, 0o755);
+await $({ nothrow: true })`strip ${destination}`;
+console.log(`built ${destination}`);

--- a/native/foreground/foreground.c
+++ b/native/foreground/foreground.c
@@ -1,0 +1,121 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+static void exec_command(char **argv) {
+  execvp(argv[0], argv);
+  perror("foreground: execvp");
+  _exit(127);
+}
+
+static int restore_tty(int tty_fd, pid_t old_pgrp) {
+  if (tcsetpgrp(tty_fd, old_pgrp) < 0) {
+    perror("foreground: restore tcsetpgrp");
+    return -1;
+  }
+  return 0;
+}
+
+static void restore_signal(int signum, void (*handler)(int)) {
+  if (signal(signum, handler) == SIG_ERR) {
+    perror("foreground: restore signal handler");
+  }
+}
+
+int main(int argc, char **argv) {
+  if (argc > 1 && argv[1][0] == '-' && argv[1][1] == '-' && argv[1][2] == '\0') {
+    argc--;
+    argv++;
+  }
+
+  if (argc < 2) {
+    fprintf(stderr, "usage: foreground [--] command [arg ...]\n");
+    return 2;
+  }
+
+  int tty_fd = open("/dev/tty", O_RDWR);
+  if (tty_fd < 0) {
+    exec_command(&argv[1]);
+  }
+
+  pid_t old_pgrp = tcgetpgrp(tty_fd);
+  if (old_pgrp < 0) {
+    perror("foreground: tcgetpgrp");
+    close(tty_fd);
+    exec_command(&argv[1]);
+  }
+
+  pid_t child = fork();
+  if (child < 0) {
+    perror("foreground: fork");
+    close(tty_fd);
+    return 1;
+  }
+
+  if (child == 0) {
+    setpgid(0, 0);
+    exec_command(&argv[1]);
+  }
+
+  if (setpgid(child, child) < 0 && errno != EACCES) {
+    perror("foreground: setpgid");
+    kill(child, SIGTERM);
+    close(tty_fd);
+    return 1;
+  }
+
+  void (*old_ttou)(int) = signal(SIGTTOU, SIG_IGN);
+  void (*old_ttin)(int) = signal(SIGTTIN, SIG_IGN);
+  void (*old_tstp)(int) = signal(SIGTSTP, SIG_IGN);
+
+  if (old_ttou == SIG_ERR || old_ttin == SIG_ERR || old_tstp == SIG_ERR) {
+    perror("foreground: install signal handler");
+    kill(child, SIGTERM);
+    close(tty_fd);
+    return 1;
+  }
+
+  if (tcsetpgrp(tty_fd, child) < 0) {
+    perror("foreground: tcsetpgrp");
+    kill(child, SIGTERM);
+    restore_tty(tty_fd, old_pgrp);
+    restore_signal(SIGTTOU, old_ttou);
+    restore_signal(SIGTTIN, old_ttin);
+    restore_signal(SIGTSTP, old_tstp);
+    close(tty_fd);
+    return 1;
+  }
+
+  int status = 0;
+  int wait_failed = 0;
+  while (waitpid(child, &status, 0) < 0) {
+    if (errno == EINTR) {
+      continue;
+    }
+    perror("foreground: waitpid");
+    wait_failed = 1;
+    break;
+  }
+
+  int restore_failed = restore_tty(tty_fd, old_pgrp) < 0;
+  restore_signal(SIGTTOU, old_ttou);
+  restore_signal(SIGTTIN, old_ttin);
+  restore_signal(SIGTSTP, old_tstp);
+  close(tty_fd);
+
+  if (wait_failed || restore_failed) {
+    return 1;
+  }
+  if (WIFEXITED(status)) {
+    return WEXITSTATUS(status);
+  }
+  if (WIFSIGNALED(status)) {
+    return 128 + WTERMSIG(status);
+  }
+  return 1;
+}

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "files": [
     "dist",
     "config/*",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "bin/**/foreground"
   ],
   "scripts": {
     "prepare": "husky",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && npm run build:foreground",
     "lint": "oxlint --type-aware --type-check --deny-warnings --fix .",
     "build": "tsup",
     "watch": "tsup --watch",
@@ -25,7 +26,8 @@
     "lint:check": "oxlint --type-aware --type-check --deny-warnings .",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "test:smoke": "pnpm run build && node scripts/smoke.mjs"
+    "test:smoke": "pnpm run build && node scripts/smoke.mjs",
+    "build:foreground": "node native/foreground/build.mjs"
   },
   "dependencies": {
     "commander": "^15.0.0",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,13 +1,26 @@
 import { $, fs, path, tmpdir } from 'zx';
+import { spawn } from 'node:child_process';
 
 $.verbose = Boolean(process.env.DEBUG);
 
 const root = process.cwd();
 const cli = path.join(root, 'dist/index.js');
 const runRoot = path.join(tmpdir(), `lockfile-conflicts-smoke-${process.pid}`);
+const managers = ['husky', 'simple-git-hooks'];
 
 function env(extra = {}) {
   return { ...process.env, ...extra };
+}
+
+function gitEnv(extra = {}) {
+  return env({
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_AUTHOR_NAME: 'a',
+    GIT_AUTHOR_EMAIL: 'a@b.c',
+    GIT_COMMITTER_NAME: 'a',
+    GIT_COMMITTER_EMAIL: 'a@b.c',
+    ...extra,
+  });
 }
 
 async function run(name, fn) {
@@ -16,13 +29,10 @@ async function run(name, fn) {
   console.log('ok');
 }
 
-async function initRepo(dir, globalConfig) {
+async function initRepo(dir) {
   await fs.remove(dir);
   await fs.ensureDir(dir);
-  await $({
-    cwd: dir,
-    env: env({ GIT_CONFIG_GLOBAL: globalConfig }),
-  })`git init -q`;
+  await $({ cwd: dir, env: gitEnv() })`git init -q`;
 }
 
 async function writeExecutable(file, content) {
@@ -41,6 +51,303 @@ async function assertNoLockfileBlock(dir) {
   }
 }
 
+function prepareScript(manager) {
+  if (manager === 'husky') return 'husky .husky && lockfile install';
+  return 'simple-git-hooks && lockfile install';
+}
+
+function hookManagerPackage(manager) {
+  if (manager === 'husky') return { husky: '^9.1.7' };
+  return { 'simple-git-hooks': '^2.13.1' };
+}
+
+async function writeConsumerPackage(repo, manager) {
+  const packageJsonPath = path.join(repo, 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+  packageJson.scripts = { prepare: prepareScript(manager) };
+  packageJson.devDependencies = hookManagerPackage(manager);
+  if (manager === 'simple-git-hooks') {
+    packageJson['simple-git-hooks'] = {
+      'post-checkout': 'echo simple-post-checkout >> .git/manager-hook.log',
+    };
+  }
+  await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
+async function createLinkedConsumer(name, manager) {
+  const repo = path.join(runRoot, name);
+  await initRepo(repo);
+  await fs.writeFile(
+    path.join(repo, 'package.json'),
+    JSON.stringify({ name, version: '1.0.0', private: true }, null, 2),
+  );
+
+  // Link first, then run pnpm install with the real consumer prepare script.
+  await $({ cwd: repo, env: gitEnv() })`pnpm link ${root}`;
+  await writeConsumerPackage(repo, manager);
+
+  if (manager === 'husky') {
+    await fs.ensureDir(path.join(repo, '.husky'));
+    await fs.writeFile(
+      path.join(repo, '.husky/post-checkout'),
+      'echo husky-post-checkout >> .git/manager-hook.log\n',
+    );
+  }
+
+  const install = await $({
+    cwd: repo,
+    env: gitEnv(),
+    nothrow: true,
+  })`pnpm i --config.dangerouslyAllowAllBuilds=true`;
+  if (install.exitCode !== 0) {
+    throw new Error(
+      `pnpm install failed for ${manager}:\n${install.stdout}\n${install.stderr}`,
+    );
+  }
+
+  const hookLog = path.join(repo, '.git/lockfile-wrapper.log');
+  await writeExecutable(
+    path.join(repo, 'node_modules/.bin/lockfile'),
+    `#!/usr/bin/env sh\necho lockfile "$@" >> ${hookLog}\nexec node ${cli} "$@"\n`,
+  );
+  await fs.remove(hookLog);
+
+  return { repo, hookLog };
+}
+
+async function commitAll(repo, message) {
+  await $({ cwd: repo, env: gitEnv() })`git add .`;
+  await $({ cwd: repo, env: gitEnv() })`git commit -q -m ${message}`;
+}
+
+async function assertManagerHookInitializedAndExecutes(manager) {
+  const { repo, hookLog } = await createLinkedConsumer(
+    `${manager}-initializes-hooks`,
+    manager,
+  );
+  await commitAll(repo, 'init');
+
+  const gitHooksPath = (
+    await $({
+      cwd: repo,
+      env: gitEnv(),
+    })`git rev-parse --path-format=absolute --git-path hooks/post-checkout`
+  )
+    .valueOf()
+    .trim();
+  if (!(await fs.pathExists(gitHooksPath))) {
+    throw new Error(
+      `expected Git-executed post-checkout hook at ${gitHooksPath}`,
+    );
+  }
+
+  if (manager === 'husky') {
+    const userHook = await fs.readFile(
+      path.join(repo, '.husky/post-checkout'),
+      'utf8',
+    );
+    if (!userHook.includes('lockfile hook post-checkout')) {
+      throw new Error(
+        `expected lockfile block in Husky user hook: ${userHook}`,
+      );
+    }
+  } else {
+    const hook = await fs.readFile(gitHooksPath, 'utf8');
+    if (
+      !hook.includes('simple-post-checkout') ||
+      !hook.includes('lockfile hook post-checkout')
+    ) {
+      throw new Error(
+        `expected simple-git-hooks and lockfile in hook: ${hook}`,
+      );
+    }
+  }
+
+  await fs.remove(path.join(repo, '.git/manager-hook.log'));
+  await fs.remove(hookLog);
+  await $({
+    cwd: repo,
+    env: gitEnv(),
+  })`git checkout -q -b verify-post-checkout`;
+
+  const managerLog = await fs.readFile(
+    path.join(repo, '.git/manager-hook.log'),
+    'utf8',
+  );
+  if (
+    !managerLog.includes(
+      `${manager === 'husky' ? 'husky' : 'simple'}-post-checkout`,
+    )
+  ) {
+    throw new Error(`expected ${manager} post-checkout marker: ${managerLog}`);
+  }
+  const lockfileLog = await fs.readFile(hookLog, 'utf8');
+  if (!lockfileLog.includes('lockfile hook post-checkout')) {
+    throw new Error(
+      `expected lockfile post-checkout execution: ${lockfileLog}`,
+    );
+  }
+}
+
+async function configureRunAfter(repo, runAfter) {
+  await fs.outputJson(path.join(repo, '.lockfile/config.json'), {
+    lockfilePattern: 'pnpm-lock.yaml',
+    runAfter,
+    commitMessage: 'chore: update lockfile',
+  });
+}
+
+async function createRealLockfileConflictRepo(manager, name, runAfter) {
+  const { repo, hookLog } = await createLinkedConsumer(name, manager);
+  await configureRunAfter(repo, runAfter);
+  await fs.writeFile(path.join(repo, 'pnpm-lock.yaml'), 'base\n');
+  await commitAll(repo, 'init');
+  await $({ cwd: repo, env: gitEnv() })`git branch -M main`;
+
+  await $({ cwd: repo, env: gitEnv() })`git checkout -q -b feature`;
+  await fs.writeFile(path.join(repo, 'pnpm-lock.yaml'), 'feature\n');
+  await commitAll(repo, 'feature lockfile');
+
+  await $({ cwd: repo, env: gitEnv() })`git checkout -q main`;
+  await fs.writeFile(path.join(repo, 'pnpm-lock.yaml'), 'main\n');
+  await commitAll(repo, 'main lockfile');
+
+  await $({ cwd: repo, env: gitEnv() })`git checkout -q feature`;
+  await fs.remove(hookLog);
+
+  return { repo, hookLog };
+}
+
+async function assertNoRebaseState(repo, label) {
+  if (await fs.pathExists(path.join(repo, '.git/rebase-merge'))) {
+    throw new Error(`expected ${label} to leave no .git/rebase-merge`);
+  }
+  if (await fs.pathExists(path.join(repo, '.git/rebase-apply'))) {
+    throw new Error(`expected ${label} to leave no .git/rebase-apply`);
+  }
+}
+
+async function runRebaseInPtyAndInterrupt(repo, extraEnv = {}) {
+  const python = await $({ nothrow: true })`command -v python3`;
+  if (python.exitCode !== 0) {
+    throw new Error('python3 is required for Ctrl+C smoke test');
+  }
+
+  const driver = String.raw`
+import os, pty, select, sys, time
+repo = sys.argv[1]
+pid, fd = pty.fork()
+if pid == 0:
+    os.chdir(repo)
+    os.execvp('git', ['git', 'rebase', 'main'])
+output = b''
+interrupt_at = None
+exit_code = 1
+while True:
+    ready, _, _ = select.select([fd], [], [], 0.1)
+    if ready:
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            chunk = b''
+        if chunk:
+            output += chunk
+            os.write(1, chunk)
+            if interrupt_at is None and b'setTimeout' in output:
+                interrupt_at = time.monotonic() + 0.5
+        else:
+            done, status = os.waitpid(pid, 0)
+            if os.WIFEXITED(status):
+                exit_code = os.WEXITSTATUS(status)
+            elif os.WIFSIGNALED(status):
+                exit_code = 128 + os.WTERMSIG(status)
+            break
+    if interrupt_at is not None and time.monotonic() >= interrupt_at:
+        os.write(fd, b'\x03')
+        interrupt_at = None
+    try:
+        done, status = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        break
+    if done == pid:
+        if os.WIFEXITED(status):
+            exit_code = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            exit_code = 128 + os.WTERMSIG(status)
+        break
+    if len(output) > 100000:
+        os.kill(pid, 15)
+        raise RuntimeError('pty output overflow')
+sys.exit(exit_code)
+`;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(python.stdout.trim(), ['-c', driver, repo], {
+      cwd: repo,
+      env: gitEnv(extraEnv),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (exitCode) => resolve({ exitCode, output }));
+  });
+}
+
+let wasForegroundHelperBuilt = false;
+async function ensureTestForegroundHelper() {
+  if (
+    wasForegroundHelperBuilt &&
+    (await fs.pathExists(path.join(root, 'bin')))
+  ) {
+    return;
+  }
+  const compiler = await $({ nothrow: true })`command -v cc`;
+  if (compiler.exitCode !== 0) {
+    throw new Error('cc is required to build foreground helper for smoke test');
+  }
+  await $({ cwd: root })`pnpm run build:foreground`;
+  wasForegroundHelperBuilt = true;
+}
+
+async function runRealRebaseWithRunAfter(manager, name, runAfter) {
+  const { repo, hookLog } = await createRealLockfileConflictRepo(
+    manager,
+    name,
+    runAfter,
+  );
+  await assertNoRebaseState(repo, 'test setup');
+
+  const rebase = await $({
+    cwd: repo,
+    env: gitEnv(),
+    nothrow: true,
+  })`git rebase main`;
+  if (rebase.exitCode !== 0) {
+    throw new Error(
+      `expected ${manager} real git rebase to continue, got ${rebase.exitCode}:\n${rebase.stdout}\n${rebase.stderr}`,
+    );
+  }
+
+  const log = await fs.readFile(hookLog, 'utf8');
+  if (!log.includes('lockfile hook post-rewrite')) {
+    throw new Error(`expected real rebase to run post-rewrite hook: ${log}`);
+  }
+  await assertNoRebaseState(repo, `${manager} real rebase`);
+  if (await fs.pathExists(path.join(repo, '.lockfile/temp'))) {
+    throw new Error(
+      `expected ${manager} real rebase hook to clean .lockfile/temp`,
+    );
+  }
+  return { repo, hookLog };
+}
+
 await fs.remove(runRoot);
 await fs.ensureDir(runRoot);
 
@@ -50,7 +357,7 @@ await run('global core.hooksPath safety', async () => {
   const globalConfig = path.join(runRoot, 'global.gitconfig');
   await fs.ensureDir(globalHooks);
   await fs.writeFile(globalConfig, `[core]\n\thooksPath = ${globalHooks}\n`);
-  await initRepo(repo, globalConfig);
+  await initRepo(repo);
 
   await $({
     cwd: repo,
@@ -64,11 +371,8 @@ await run('global core.hooksPath safety', async () => {
 
 await run('missing lockfile command exits zero', async () => {
   const repo = path.join(runRoot, 'missing-command');
-  await initRepo(repo, '/dev/null');
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`node ${cli} install`;
+  await initRepo(repo);
+  await $({ cwd: repo, env: gitEnv() })`node ${cli} install`;
   await $({
     cwd: repo,
     env: { PATH: '/usr/bin:/bin', GIT_CONFIG_GLOBAL: '/dev/null' },
@@ -77,31 +381,25 @@ await run('missing lockfile command exits zero', async () => {
 
 await run('missing config exits zero', async () => {
   const repo = path.join(runRoot, 'missing-config');
-  await initRepo(repo, '/dev/null');
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`node ${cli} install`;
+  await initRepo(repo);
+  await $({ cwd: repo, env: gitEnv() })`node ${cli} install`;
   await writeExecutable(
     path.join(repo, 'node_modules/.bin/lockfile'),
     `#!/usr/bin/env sh\nexec node ${cli} "$@"\n`,
   );
   await fs.remove(path.join(repo, '.lockfile'));
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`bash .git/hooks/post-checkout`;
+  await $({ cwd: repo, env: gitEnv() })`bash .git/hooks/post-checkout`;
 });
 
 await run('nested config resolves sibling node_modules bin', async () => {
   const repo = path.join(runRoot, 'nested-config');
   const result = path.join(runRoot, 'nested-config-result');
-  await initRepo(repo, '/dev/null');
+  await initRepo(repo);
   await fs.ensureDir(path.join(repo, 'packages/app'));
   await fs.writeFile(path.join(repo, 'packages/app/package.json'), '{}');
   await $({
     cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
+    env: gitEnv(),
   })`node ${cli} install packages/app/.lockfile`;
   await writeExecutable(
     path.join(repo, 'node_modules/.bin/lockfile'),
@@ -112,44 +410,21 @@ await run('nested config resolves sibling node_modules bin', async () => {
     `#!/usr/bin/env sh\necho nested-lockfile >> ${result}\nexit 0\n`,
   );
   await fs.remove(result);
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`bash .git/hooks/post-checkout`;
+  await $({ cwd: repo, env: gitEnv() })`bash .git/hooks/post-checkout`;
   const output = await fs.readFile(result, 'utf8');
   if (!output.includes('nested-lockfile') || output.includes('root-lockfile')) {
     throw new Error(`unexpected nested config output: ${output}`);
   }
 });
 
-await run('failing runAfter exits zero', async () => {
+await run('legacy failing runAfter hook exits zero', async () => {
   const repo = path.join(runRoot, 'runafter-fail');
-  await initRepo(repo, '/dev/null');
+  await initRepo(repo);
   await fs.writeFile(path.join(repo, 'package.json'), '{}');
   await fs.writeFile(path.join(repo, 'pnpm-lock.yaml'), 'lock');
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`git add package.json pnpm-lock.yaml`;
-  await $({
-    cwd: repo,
-    env: env({
-      GIT_CONFIG_GLOBAL: '/dev/null',
-      GIT_AUTHOR_NAME: 'a',
-      GIT_AUTHOR_EMAIL: 'a@b.c',
-      GIT_COMMITTER_NAME: 'a',
-      GIT_COMMITTER_EMAIL: 'a@b.c',
-    }),
-  })`git commit -q -m init`;
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`node ${cli} install`;
-  await fs.outputJson(path.join(repo, '.lockfile/config.json'), {
-    lockfilePattern: 'pnpm-lock.yaml',
-    runAfter: 'node -e "process.exit(1)"',
-    commitMessage: 'chore: update lockfile',
-  });
+  await commitAll(repo, 'init');
+  await $({ cwd: repo, env: gitEnv() })`node ${cli} install`;
+  await configureRunAfter(repo, 'node -e "process.exit(1)"');
   await fs.outputFile(
     path.join(repo, '.lockfile/temp/conflicts'),
     'pnpm-lock.yaml',
@@ -169,15 +444,12 @@ await run('failing runAfter exits zero', async () => {
     path.join(repo, '.lockfile/temp/conflicts'),
     'pnpm-lock.yaml',
   );
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`bash .git/hooks/post-commit`;
+  await $({ cwd: repo, env: gitEnv() })`bash .git/hooks/post-commit`;
 });
 
 await run('Husky v9 shim target', async () => {
   const repo = path.join(runRoot, 'husky');
-  await initRepo(repo, '/dev/null');
+  await initRepo(repo);
   await fs.ensureDir(path.join(repo, '.husky/_'));
   await writeExecutable(
     path.join(repo, '.husky/_/h'),
@@ -189,21 +461,20 @@ await run('Husky v9 shim target', async () => {
   );
   await $({
     cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
+    env: gitEnv(),
   })`git config --local core.hooksPath .husky/_`;
-  await $({
-    cwd: repo,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`node ${cli} install`;
+  await $({ cwd: repo, env: gitEnv() })`node ${cli} install`;
   const parentHook = path.join(repo, '.husky/post-checkout');
-  if (!(await fs.pathExists(parentHook)))
+  if (!(await fs.pathExists(parentHook))) {
     throw new Error('expected parent Husky hook');
+  }
   const shim = await fs.readFile(
     path.join(repo, '.husky/_/post-checkout'),
     'utf8',
   );
-  if (shim.includes('lockfile hook'))
+  if (shim.includes('lockfile hook')) {
     throw new Error('unexpected injection in Husky shim');
+  }
   await $({
     cwd: repo,
     env: { PATH: '/usr/bin:/bin', GIT_CONFIG_GLOBAL: '/dev/null' },
@@ -213,19 +484,13 @@ await run('Husky v9 shim target', async () => {
 await run('shared worktree hook resolves current worktree bin', async () => {
   const main = path.join(runRoot, 'worktree-main');
   const linked = path.join(runRoot, 'worktree-linked');
-  await initRepo(main, '/dev/null');
+  await initRepo(main);
   await fs.writeFile(path.join(main, 'a'), 'a');
-  const gitEnv = env({
-    GIT_CONFIG_GLOBAL: '/dev/null',
-    GIT_AUTHOR_NAME: 'a',
-    GIT_AUTHOR_EMAIL: 'a@b.c',
-    GIT_COMMITTER_NAME: 'a',
-    GIT_COMMITTER_EMAIL: 'a@b.c',
-  });
-  await $({ cwd: main, env: gitEnv })`git add a`;
-  await $({ cwd: main, env: gitEnv })`git commit -q -m init`;
-  await $({ cwd: main, env: gitEnv })`git worktree add -q ${linked}`;
-  await $({ cwd: main, env: gitEnv })`node ${cli} install`;
+  const worktreeEnv = gitEnv();
+  await $({ cwd: main, env: worktreeEnv })`git add a`;
+  await $({ cwd: main, env: worktreeEnv })`git commit -q -m init`;
+  await $({ cwd: main, env: worktreeEnv })`git worktree add -q ${linked}`;
+  await $({ cwd: main, env: worktreeEnv })`node ${cli} install`;
 
   const result = path.join(runRoot, 'worktree-result');
   await writeExecutable(
@@ -242,14 +507,90 @@ await run('shared worktree hook resolves current worktree bin', async () => {
     `#!/usr/bin/env sh\necho linked-lockfile "$PWD" >> ${result}\nexit 0\n`,
   );
   await fs.remove(result);
-  await $({
-    cwd: linked,
-    env: env({ GIT_CONFIG_GLOBAL: '/dev/null' }),
-  })`bash ${path.join(main, '.git/hooks/post-checkout')}`;
+  await $({ cwd: linked, env: gitEnv() })`bash ${path.join(
+    main,
+    '.git/hooks/post-checkout',
+  )}`;
   const output = await fs.readFile(result, 'utf8');
   if (!output.includes(`linked-lockfile ${linked}`)) {
     throw new Error(`unexpected worktree output: ${output}`);
   }
 });
+
+for (const manager of managers) {
+  await run(
+    `${manager} pnpm-linked install initializes and executes hooks`,
+    () => assertManagerHookInitializedAndExecutes(manager),
+  );
+
+  await run(`${manager} failed runAfter does not fail real rebase`, () =>
+    runRealRebaseWithRunAfter(
+      manager,
+      `${manager}-runafter-fail-real-rebase`,
+      'node -e "process.exit(1)"',
+    ),
+  );
+
+  await run(
+    `${manager} interrupted runAfter cleans temp and does not fail real rebase`,
+    () =>
+      runRealRebaseWithRunAfter(
+        manager,
+        `${manager}-runafter-interrupt-real-rebase`,
+        'sh -c "kill -INT $PPID; exit 130"',
+      ),
+  );
+
+  await run(
+    `${manager} missing foreground helper falls back to direct runAfter`,
+    async () => {
+      await fs.remove(path.join(root, 'bin'));
+      wasForegroundHelperBuilt = false;
+      const { repo } = await runRealRebaseWithRunAfter(
+        manager,
+        `${manager}-missing-helper-fallback-real-rebase`,
+        `node -e "require('fs').writeFileSync('.git/runafter-marker','ok')"`,
+      );
+      const marker = await fs.readFile(
+        path.join(repo, '.git/runafter-marker'),
+        'utf8',
+      );
+      if (marker !== 'ok') {
+        throw new Error(`expected fallback runAfter marker, got ${marker}`);
+      }
+    },
+  );
+
+  await run(
+    `${manager} Ctrl+C in real runAfter does not interrupt real rebase`,
+    async () => {
+      await ensureTestForegroundHelper();
+      if (!(await fs.pathExists(path.join(root, 'bin')))) {
+        throw new Error('expected packaged foreground helper to exist');
+      }
+      const { repo, hookLog } = await createRealLockfileConflictRepo(
+        manager,
+        `${manager}-runafter-ctrl-c-real-rebase`,
+        'node -e "setTimeout(()=>{},30000)"',
+      );
+      const rebase = await runRebaseInPtyAndInterrupt(repo);
+      if (rebase.exitCode !== 0) {
+        throw new Error(
+          `expected interrupted runAfter rebase to finish, got ${rebase.exitCode}:\n${rebase.output}`,
+        );
+      }
+      await assertNoRebaseState(repo, `${manager} Ctrl+C real rebase`);
+      if (await fs.pathExists(path.join(repo, '.lockfile/temp'))) {
+        throw new Error(`expected ${manager} Ctrl+C rebase to clean temp`);
+      }
+      const log = await fs.readFile(hookLog, 'utf8');
+      if (!log.includes('lockfile hook post-rewrite')) {
+        throw new Error(
+          `expected real rebase to run post-rewrite hook: ${log}`,
+        );
+      }
+    },
+  );
+}
 
 await fs.remove(runRoot);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'child_process';
 import { commitMessage as defaultCommitMessage } from '../config/config.json';
+import { runAfterCommand } from './run-after';
 import {
   conflictFileName,
   getConfigDir,
@@ -11,6 +11,10 @@ import {
   splitFile,
   hooks,
 } from '@/utils';
+
+async function cleanIgnoredFiles(configDir: string) {
+  await $`git clean -Xfd ${configDir}`; // Cleanup ignored files/directories.
+}
 
 export default async (hook: keyof typeof hooks) => {
   if (shouldSkipExec()) return; // Avoid loop.
@@ -40,7 +44,7 @@ export default async (hook: keyof typeof hooks) => {
   const isLogFileExist = fs.existsSync(logFile);
   const conflictFiles = new Set(isLogFileExist ? splitFile(logFile) : []);
 
-  await $`git clean -Xf ${configDir}`; // Cleanup ignored files.
+  await cleanIgnoredFiles(configDir);
 
   if (!conflictFiles.size) return; // No conflicts, exit.
 
@@ -68,23 +72,41 @@ export default async (hook: keyof typeof hooks) => {
       ),
     );
 
+    let wasInterrupted = false;
+    const markInterrupted = () => {
+      wasInterrupted = true;
+    };
+
+    process.once('SIGINT', markInterrupted);
+    process.once('SIGTERM', markInterrupted);
+
     try {
       const [cmd, ...params] = runAfter.trim().split(' ');
       logger.info(`$ ${chalk.green(cmd)} ${params.join(' ')}`);
-      execSync(runAfter, { stdio: 'inherit', encoding: 'utf8' });
+
+      runAfterCommand(runAfter);
     } catch (e: any) {
       const output = e.stderr || e.stdout;
       if (output) {
         console.log(output);
       }
       const failedCommand = e.cmd || runAfter;
-      const reason = e.signal ? `signal ${e.signal}` : `exit code ${e.status}`;
+      const reason = e.signal
+        ? `signal ${e.signal}`
+        : wasInterrupted
+          ? 'interrupted'
+          : `exit code ${e.status}`;
       return logger.error(
         chalk.bold(
           `Failed to run ${chalk.underline(failedCommand)} (${reason}), ` +
             'please manually make sure the lockfile is up-to-date.',
         ),
       );
+    } finally {
+      await cleanIgnoredFiles(configDir);
+
+      process.removeListener('SIGINT', markInterrupted);
+      process.removeListener('SIGTERM', markInterrupted);
     }
 
     let wasHit = false;

--- a/src/run-after.ts
+++ b/src/run-after.ts
@@ -1,0 +1,45 @@
+import { execFileSync, execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+export const foregroundHelperEnvName = 'LOCKFILE_FOREGROUND_HELPER';
+
+function packageRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+function linuxLibcSuffix() {
+  if (process.platform !== 'linux') return '';
+  const report = process.report?.getReport?.() as
+    | { header?: { glibcVersionRuntime?: string } }
+    | undefined;
+  return report?.header?.glibcVersionRuntime ? '-gnu' : '-musl';
+}
+
+export function getForegroundHelperPath() {
+  const override = process.env[foregroundHelperEnvName];
+  if (override && fs.existsSync(override)) return override;
+
+  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+    return;
+  }
+  if (process.arch !== 'x64' && process.arch !== 'arm64') {
+    return;
+  }
+
+  const target = `${process.platform}-${process.arch}${linuxLibcSuffix()}`;
+  const helperPath = path.join(packageRoot(), 'bin', target, 'foreground');
+  return fs.existsSync(helperPath) ? helperPath : undefined;
+}
+
+export function runAfterCommand(command: string) {
+  const helperPath = getForegroundHelperPath();
+  if (helperPath) {
+    execFileSync(helperPath!, ['sh', '-c', command], {
+      stdio: 'inherit',
+      encoding: 'utf8',
+    });
+    return;
+  }
+
+  execSync(command, { stdio: 'inherit', encoding: 'utf8' });
+}


### PR DESCRIPTION
## Summary
- add a tiny native foreground helper to run runAfter in its own tty foreground process group
- package foreground helpers via release/test publish workflows under bin/<target>/foreground
- add timestamp-based alpha/beta/next test publishing workflow
- restore and extend smoke coverage for real rebase failures, Ctrl+C interruption, and helper fallback

## Verification
- pnpm run format:check
- pnpm exec tsc --noEmit
- pnpm run lint:check
- pnpm run test:smoke
- pnpm pack --dry-run
