### PR TITLE
chore: update artifact actions

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -69,7 +69,7 @@ jobs:
           chmod +x "bin/${{ matrix.package_target }}/foreground"
           ls -lh "bin/${{ matrix.package_target }}/foreground"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: foreground-${{ matrix.package_target }}
           path: bin/${{ matrix.package_target }}/foreground
@@ -90,7 +90,7 @@ jobs:
         with:
           run_install: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           pattern: foreground-*
           path: bin-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           chmod +x "bin/${{ matrix.package_target }}/foreground"
           ls -lh "bin/${{ matrix.package_target }}/foreground"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: foreground-${{ matrix.package_target }}
           path: bin/${{ matrix.package_target }}/foreground
@@ -87,7 +87,7 @@ jobs:
         with:
           run_install: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           pattern: foreground-*
           path: bin-artifacts


### PR DESCRIPTION
## Summary\n- update actions/upload-artifact to v7.0.1\n- update actions/download-artifact to v8.0.1\n\n## Verification\n- git diff --check\n- verified action metadata uses node24 and existing inputs are still present