### PR TITLE
chore: simplify hook injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # lockfile-conflicts
 
+## 0.5.0
+
+### Minor Changes
+
+- Add a native foreground helper so Ctrl+C during `runAfter` does not interrupt an in-progress Git rebase.
+- Make hook cleanup resilient when `runAfter` or lockfile hook execution fails, avoiding stale Git rebase state.
+- Package foreground helper binaries for common Linux and macOS targets and fall back to the previous direct execution path when no helper is available.
+- Add a timestamped test-publish workflow for alpha/beta/next prereleases.
+- Simplify generated hook injection so it only prepends the local bin directory to find `lockfile`; runAfter keeps using the user's normal environment.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lockfile-conflicts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "packageManager": "pnpm@11.5.2",
   "description": "A custom merge driver, aims to handle lockfile conflicts automatically in merge/rebase process.",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -151,6 +151,9 @@ async function assertManagerHookInitializedAndExecutes(manager) {
         `expected lockfile block in Husky user hook: ${userHook}`,
       );
     }
+    if (userHook.includes('git rev-parse --show-toplevel')) {
+      throw new Error(`expected simplified Husky hook block: ${userHook}`);
+    }
   } else {
     const hook = await fs.readFile(gitHooksPath, 'utf8');
     if (
@@ -160,6 +163,9 @@ async function assertManagerHookInitializedAndExecutes(manager) {
       throw new Error(
         `expected simple-git-hooks and lockfile in hook: ${hook}`,
       );
+    }
+    if (hook.includes('git rev-parse --show-toplevel')) {
+      throw new Error(`expected simplified simple-git-hooks block: ${hook}`);
     }
   }
 

--- a/src/utils/inject.ts
+++ b/src/utils/inject.ts
@@ -45,9 +45,7 @@ export async function injectShellScript(filePath: string, scripts: string[]) {
     // Keep environment changes inside this subshell and resolve the executable
     // from the current worktree at runtime.
     [
-      'repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)',
-      'cd "$repo_root" || exit 0',
-      `export PATH=${binDir}:$PATH`,
+      `export PATH=${quoteShellPath(binDir)}:$PATH`,
       'command -v lockfile >/dev/null 2>&1 || exit 0',
       ...scripts,
     ],
@@ -116,6 +114,11 @@ export async function injectGitAttributes() {
   } else {
     appendFile(filePath, pattern);
   }
+}
+
+/** Quote a path so the injected hook remains valid for paths with spaces or quotes. */
+function quoteShellPath(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 /** Append content to the end of file and add a newline if needed */


### PR DESCRIPTION
## Summary\n- simplify injected hook blocks by removing inline repo-root resolution\n- move repo-root cwd normalization and PATH setup into the lockfile hook command\n- add smoke assertions that generated hook blocks no longer include git rev-parse root lookup\n\n## Verification\n- pnpm exec tsc --noEmit\n- pnpm run lint:check\n- pnpm run test:smoke