### PR TITLE
fix: repair foreground helper permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # lockfile-conflicts
 
+## 0.5.1
+
+### Patch Changes
+
+- Repair packaged foreground helper executable permissions at runtime, falling back to direct `runAfter` execution if the helper cannot be made executable.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lockfile-conflicts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "packageManager": "pnpm@11.5.2",
   "description": "A custom merge driver, aims to handle lockfile conflicts automatically in merge/rebase process.",
@@ -41,13 +41,14 @@
     "@changesets/cli": "^2.31.0",
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "25.9.1",
     "husky": "^9.1.7",
-    "tsup": "^8.5.1",
-    "typescript": "^6.0.3",
+    "oxfmt": "^0.53.0",
     "oxlint": "^1.68.0",
     "oxlint-tsgolint": "^0.23.0",
-    "oxfmt": "^0.53.0"
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3"
   },
   "keywords": [
     "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^21.0.2
         version: 21.0.2
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/node':
         specifier: 25.9.1
         version: 25.9.1
@@ -838,6 +841,12 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2331,6 +2340,15 @@ snapshots:
   '@simple-libs/stream-utils@1.2.0': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 25.9.1
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 25.9.1
 
   '@types/node@12.20.55': {}
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -306,6 +306,20 @@ sys.exit(exit_code)
   });
 }
 
+function currentPackageTarget() {
+  const libc =
+    process.platform === 'linux'
+      ? process.report?.getReport?.().header?.glibcVersionRuntime
+        ? '-gnu'
+        : '-musl'
+      : '';
+  return `${process.platform}-${process.arch}${libc}`;
+}
+
+function currentForegroundHelperPath() {
+  return path.join(root, 'bin', currentPackageTarget(), 'foreground');
+}
+
 let wasForegroundHelperBuilt = false;
 async function ensureTestForegroundHelper() {
   if (
@@ -563,6 +577,34 @@ for (const manager of managers) {
       );
       if (marker !== 'ok') {
         throw new Error(`expected fallback runAfter marker, got ${marker}`);
+      }
+    },
+  );
+
+  await run(
+    `${manager} non-executable foreground helper is repaired`,
+    async () => {
+      await ensureTestForegroundHelper();
+      const helperPath = currentForegroundHelperPath();
+      await fs.chmod(helperPath, 0o644);
+      const { repo } = await runRealRebaseWithRunAfter(
+        manager,
+        `${manager}-non-executable-helper-real-rebase`,
+        `node -e "require('fs').writeFileSync('.git/runafter-marker','ok')"`,
+      );
+      const marker = await fs.readFile(
+        path.join(repo, '.git/runafter-marker'),
+        'utf8',
+      );
+      if (marker !== 'ok') {
+        throw new Error(`expected runAfter marker, got ${marker}`);
+      }
+      try {
+        await fs.access(helperPath, fs.constants.X_OK);
+      } catch {
+        throw new Error(
+          'expected foreground helper executable bit to be repaired',
+        );
       }
     },
   );

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -83,6 +83,7 @@ export default async (hook: keyof typeof hooks) => {
     try {
       const [cmd, ...params] = runAfter.trim().split(' ');
       logger.info(`$ ${chalk.green(cmd)} ${params.join(' ')}`);
+      console.log();
 
       runAfterCommand(runAfter);
     } catch (e: any) {
@@ -103,6 +104,7 @@ export default async (hook: keyof typeof hooks) => {
         ),
       );
     } finally {
+      console.log();
       await cleanIgnoredFiles(configDir);
 
       process.removeListener('SIGINT', markInterrupted);

--- a/src/run-after.ts
+++ b/src/run-after.ts
@@ -3,6 +3,27 @@ import { fileURLToPath } from 'url';
 
 export const foregroundHelperEnvName = 'LOCKFILE_FOREGROUND_HELPER';
 
+function isExecutable(filePath: string) {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureExecutable(filePath: string) {
+  if (isExecutable(filePath)) return true;
+
+  try {
+    fs.chmodSync(filePath, 0o755);
+  } catch {
+    return false;
+  }
+
+  return isExecutable(filePath);
+}
+
 function packageRoot() {
   return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 }
@@ -17,7 +38,9 @@ function linuxLibcSuffix() {
 
 export function getForegroundHelperPath() {
   const override = process.env[foregroundHelperEnvName];
-  if (override && fs.existsSync(override)) return override;
+  if (override && fs.existsSync(override) && ensureExecutable(override)) {
+    return override;
+  }
 
   if (process.platform !== 'darwin' && process.platform !== 'linux') {
     return;
@@ -28,7 +51,9 @@ export function getForegroundHelperPath() {
 
   const target = `${process.platform}-${process.arch}${linuxLibcSuffix()}`;
   const helperPath = path.join(packageRoot(), 'bin', target, 'foreground');
-  return fs.existsSync(helperPath) ? helperPath : undefined;
+  return fs.existsSync(helperPath) && ensureExecutable(helperPath)
+    ? helperPath
+    : undefined;
 }
 
 export function runAfterCommand(command: string) {


### PR DESCRIPTION
## Summary\n- repair packaged foreground helper executable bit at runtime before using it\n- fall back to direct runAfter execution if the helper cannot be made executable\n- add smoke coverage for 0644 helper files, matching the published 0.5.0 tarball behavior\n- bump patch version to 0.5.1 and document the fix\n\n## Verification\n- pnpm run format:check\n- pnpm exec tsc --noEmit\n- pnpm run lint:check\n- pnpm run test:smoke\n- git diff --check