### PR TITLE
chore: restore runAfter log spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lockfile-conflicts
 
+## 0.5.2
+
+### Patch Changes
+
+- Improve interrupted `runAfter` reporting so Ctrl+C displays as `interrupted` instead of `exit code 130`.
+- Stop lingering `runAfter` process groups after Ctrl+C so command output does not continue after Git rebase completes.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/native/foreground/foreground.c
+++ b/native/foreground/foreground.c
@@ -27,6 +27,32 @@ static void restore_signal(int signum, void (*handler)(int)) {
   }
 }
 
+static int is_interrupted_status(int status) {
+  if (WIFSIGNALED(status)) {
+    int signal_number = WTERMSIG(status);
+    return signal_number == SIGINT || signal_number == SIGTERM;
+  }
+  if (WIFEXITED(status)) {
+    int exit_code = WEXITSTATUS(status);
+    return exit_code == 130 || exit_code == 143;
+  }
+  return 0;
+}
+
+static void terminate_process_group(pid_t pgid) {
+  if (pgid <= 0) {
+    return;
+  }
+
+  if (kill(-pgid, SIGTERM) < 0 && errno != ESRCH) {
+    perror("foreground: terminate process group");
+  }
+  usleep(100000);
+  if (kill(-pgid, SIGKILL) < 0 && errno != ESRCH) {
+    perror("foreground: kill process group");
+  }
+}
+
 int main(int argc, char **argv) {
   if (argc > 1 && argv[1][0] == '-' && argv[1][1] == '-' && argv[1][2] == '\0') {
     argc--;
@@ -100,6 +126,10 @@ int main(int argc, char **argv) {
     perror("foreground: waitpid");
     wait_failed = 1;
     break;
+  }
+
+  if (!wait_failed && is_interrupted_status(status)) {
+    terminate_process_group(child);
   }
 
   int restore_failed = restore_tty(tty_fd, old_pgrp) < 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lockfile-conflicts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "packageManager": "pnpm@11.5.2",
   "description": "A custom merge driver, aims to handle lockfile conflicts automatically in merge/rebase process.",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -336,7 +336,12 @@ async function ensureTestForegroundHelper() {
   wasForegroundHelperBuilt = true;
 }
 
-async function runRealRebaseWithRunAfter(manager, name, runAfter) {
+async function runRealRebaseWithRunAfter(
+  manager,
+  name,
+  runAfter,
+  options = {},
+) {
   const { repo, hookLog } = await createRealLockfileConflictRepo(
     manager,
     name,
@@ -349,9 +354,23 @@ async function runRealRebaseWithRunAfter(manager, name, runAfter) {
     env: gitEnv(),
     nothrow: true,
   })`git rebase main`;
+  const rebaseOutput = `${rebase.stdout}\n${rebase.stderr}`;
   if (rebase.exitCode !== 0) {
     throw new Error(
-      `expected ${manager} real git rebase to continue, got ${rebase.exitCode}:\n${rebase.stdout}\n${rebase.stderr}`,
+      `expected ${manager} real git rebase to continue, got ${rebase.exitCode}:\n${rebaseOutput}`,
+    );
+  }
+  if (
+    options.outputIncludes &&
+    !rebaseOutput.includes(options.outputIncludes)
+  ) {
+    throw new Error(
+      `expected ${manager} rebase output to include ${options.outputIncludes}:\n${rebaseOutput}`,
+    );
+  }
+  if (options.outputExcludes && rebaseOutput.includes(options.outputExcludes)) {
+    throw new Error(
+      `expected ${manager} rebase output not to include ${options.outputExcludes}:\n${rebaseOutput}`,
     );
   }
 
@@ -558,6 +577,10 @@ for (const manager of managers) {
         manager,
         `${manager}-runafter-interrupt-real-rebase`,
         'sh -c "kill -INT $PPID; exit 130"',
+        {
+          outputIncludes: '(interrupted)',
+          outputExcludes: '(exit code 130)',
+        },
       ),
   );
 
@@ -610,6 +633,40 @@ for (const manager of managers) {
   );
 
   await run(
+    `${manager} Ctrl+C stops lingering runAfter process group`,
+    async () => {
+      await ensureTestForegroundHelper();
+      const { repo } = await createRealLockfileConflictRepo(
+        manager,
+        `${manager}-runafter-ctrl-c-lingering-process`,
+        `sh -c '(trap "" INT TERM HUP; while :; do echo lingering >> .git/linger; sleep 0.05; done) & node -e "console.log(\\"setTimeout lingering\\"); setTimeout(()=>{},30000)"'`,
+      );
+      const rebase = await runRebaseInPtyAndInterrupt(repo);
+      if (rebase.exitCode !== 0) {
+        throw new Error(
+          `expected lingering runAfter rebase to finish, got ${rebase.exitCode}:
+${rebase.output}`,
+        );
+      }
+      const lingerFile = path.join(repo, '.git/linger');
+      const before = (await fs.pathExists(lingerFile))
+        ? (await fs.readFile(lingerFile, 'utf8')).split('\n').filter(Boolean)
+            .length
+        : 0;
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const after = (await fs.pathExists(lingerFile))
+        ? (await fs.readFile(lingerFile, 'utf8')).split('\n').filter(Boolean)
+            .length
+        : 0;
+      if (after > before) {
+        throw new Error(
+          `expected interrupted runAfter process group to stop, linger lines grew from ${before} to ${after}`,
+        );
+      }
+    },
+  );
+
+  await run(
     `${manager} Ctrl+C in real runAfter does not interrupt real rebase`,
     async () => {
       await ensureTestForegroundHelper();
@@ -625,6 +682,16 @@ for (const manager of managers) {
       if (rebase.exitCode !== 0) {
         throw new Error(
           `expected interrupted runAfter rebase to finish, got ${rebase.exitCode}:\n${rebase.output}`,
+        );
+      }
+      if (!rebase.output.includes('(interrupted)')) {
+        throw new Error(
+          `expected interrupted reason in Ctrl+C output:\n${rebase.output}`,
+        );
+      }
+      if (rebase.output.includes('(exit code 130)')) {
+        throw new Error(
+          `expected no exit code 130 reason in Ctrl+C output:\n${rebase.output}`,
         );
       }
       await assertNoRebaseState(repo, `${manager} Ctrl+C real rebase`);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -83,7 +83,6 @@ export default async (hook: keyof typeof hooks) => {
     try {
       const [cmd, ...params] = runAfter.trim().split(' ');
       logger.info(`$ ${chalk.green(cmd)} ${params.join(' ')}`);
-      console.log();
 
       runAfterCommand(runAfter);
     } catch (e: any) {
@@ -92,11 +91,20 @@ export default async (hook: keyof typeof hooks) => {
         console.log(output);
       }
       const failedCommand = e.cmd || runAfter;
-      const reason = e.signal
-        ? `signal ${e.signal}`
-        : wasInterrupted
-          ? 'interrupted'
+      const wasInterruptedBySignal =
+        wasInterrupted ||
+        e.signal === 'SIGINT' ||
+        e.signal === 'SIGTERM' ||
+        e.status === 130 ||
+        e.status === 143;
+      const reason = wasInterruptedBySignal
+        ? 'interrupted'
+        : e.signal
+          ? `signal ${e.signal}`
           : `exit code ${e.status}`;
+      if (wasInterruptedBySignal) {
+        process.stdout.write('\n');
+      }
       return logger.error(
         chalk.bold(
           `Failed to run ${chalk.underline(failedCommand)} (${reason}), ` +
@@ -104,7 +112,6 @@ export default async (hook: keyof typeof hooks) => {
         ),
       );
     } finally {
-      console.log();
       await cleanIgnoredFiles(configDir);
 
       process.removeListener('SIGINT', markInterrupted);

--- a/src/utils/inject.ts
+++ b/src/utils/inject.ts
@@ -84,7 +84,7 @@ export async function removeGitAttributes() {
   }
 
   if (wasHit) {
-    fs.writeFile(filePath, lines.join('\n'));
+    await fs.writeFile(filePath, lines.join('\n'));
   }
 }
 


### PR DESCRIPTION
## Summary\n- remove the extra blank lines around runAfter output\n- await async git attributes write to satisfy lint\n\n## Verification\n- pnpm exec tsc --noEmit\n- pnpm run lint:check\n- pnpm run test:smoke\n- git diff --check